### PR TITLE
Fix typo in documentation for example server

### DIFF
--- a/packages/openapi-to-graphql/README.md
+++ b/packages/openapi-to-graphql/README.md
@@ -49,7 +49,7 @@ const { createGraphQlSchema } = require('openapi-to-graphql')
 
 async function main(oas) {
   // generate schema:
-  const { schema, report } = await createGraphQLSchema(oas)
+  const { schema, report } = await createGraphQlSchema(oas)
 
   // server schema:
   const app = express()


### PR DESCRIPTION
The casing was incorrect for `createGraphQlSchema` in the example server implementation.