### PR TITLE
Suport arbitrary JSON pointer references

### DIFF
--- a/packages/openapi-to-graphql/package-lock.json
+++ b/packages/openapi-to-graphql/package-lock.json
@@ -6511,6 +6511,11 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-ptr": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-1.2.0.tgz",
+      "integrity": "sha512-wkqozzmmyu+vtazHF11uvIDbLsgkE4juY41QoXgKYSy166KQalyc72PqveII21f8UWKtYN7btUXg16vya+9xnw=="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",

--- a/packages/openapi-to-graphql/package.json
+++ b/packages/openapi-to-graphql/package.json
@@ -71,6 +71,7 @@
     "form-urlencoded": "^4.1.1",
     "graphql-subscriptions": "^1.1.0",
     "graphql-type-json": "^0.2.1",
+    "json-ptr": "^1.2.0",
     "jsonpath-plus": "^3.0.0",
     "oas-validator": "^3.1.0",
     "pluralize": "^8.0.0",

--- a/packages/openapi-to-graphql/src/oas_3_tools.ts
+++ b/packages/openapi-to-graphql/src/oas_3_tools.ts
@@ -40,6 +40,7 @@ import * as Swagger2OpenAPI from 'swagger2openapi'
 import * as OASValidator from 'oas-validator'
 import debug from 'debug'
 import { handleWarning } from './utils'
+import * as jsonptr from 'json-ptr'
 import * as pluralize from 'pluralize'
 
 // Type definitions & exports:
@@ -231,37 +232,7 @@ export function countOperationsWithPayload(oas: Oas3): number {
  * Resolves the given reference in the given object.
  */
 export function resolveRef(ref: string, oas: Oas3): any {
-  // Break path into individual tokens
-  const parts = ref.split('/')
-  const resolvedObject = resolveRefHelper(oas, parts)
-
-  if (resolvedObject !== null) {
-    return resolvedObject
-  } else {
-    throw new Error(
-      `Could not resolve reference '${ref}' in OAS '${oas.info.title}'`
-    )
-  }
-}
-
-/**
- * Helper for resolveRef
- *
- * @param parts The path to be resolved, but broken into tokens
- */
-function resolveRefHelper(obj: object, parts?: string[]): any {
-  if (parts.length === 0) {
-    return obj
-  }
-
-  const firstElement = parts.splice(0, 1)[0]
-  if (firstElement in obj) {
-    return resolveRefHelper(obj[firstElement], parts)
-  } else if (firstElement === '#') {
-    return resolveRefHelper(obj, parts)
-  } else {
-    return null
-  }
+  return jsonptr.get(oas, ref)
 }
 
 /**

--- a/packages/openapi-to-graphql/test/oas_3_tools.test.ts
+++ b/packages/openapi-to-graphql/test/oas_3_tools.test.ts
@@ -14,6 +14,7 @@ const {
   graphql
 } = require('graphql')
 import * as Oas3Tools from '../lib/oas_3_tools'
+import { PathItemObject } from '../lib/types/oas3'
 
 test('Applying sanitize multiple times does not change outcome', () => {
   const str = 'this Super*annoying-string()'
@@ -179,4 +180,39 @@ test('Properly treat null values during sanitization', () => {
       }
     })
   })
+})
+
+test('Handle encoded JSON pointer references', () => {
+  const oas = {
+    openapi: '3.0.0',
+    info: {
+      title: 'test',
+      version: '0.0.1'
+    },
+    paths: {
+      '/users': getPathItemObject('all'),
+      '/users/{id}': getPathItemObject('one')
+    }
+  }
+
+  expect(Oas3Tools.resolveRef('/openapi', oas)).toBe('3.0.0')
+  expect(Oas3Tools.resolveRef('/paths/~1users/description', oas)).toBe('all')
+  expect(Oas3Tools.resolveRef('#/paths/~1users/description', oas)).toBe('all')
+  expect(
+    Oas3Tools.resolveRef('#/paths/~1users~1%7bid%7d/description', oas)
+  ).toBe('one')
+
+  function getPathItemObject(description): PathItemObject {
+    return {
+      description,
+      get: {},
+      put: {},
+      post: {},
+      delete: {},
+      options: {},
+      head: {},
+      patch: {},
+      trace: {}
+    }
+  }
 })


### PR DESCRIPTION
First off, thank you for writing this tool. It has been very useful to my team.

We ran into an issue recently when importing OpenAPI specs which contain references (for example, [PagerDuty's](https://raw.githubusercontent.com/PagerDuty/api-schema/master/reference/REST/openapiv3.json)). With this change, we were able to import them as expected. The root cause seems to be that references in API specs can contain characters which require escaping as described in [RFC 6901](https://tools.ietf.org/html/rfc6901) (forward slashes are particularly common in API specs since they are used as path item key). This PR leverages `json-ptr` to handle this and support arbitrary references.

Signed-off-by: Matthieu Monsch <matthieu.monsch@gmail.com>