### PR TITLE
Check that the err entity is not a string

### DIFF
--- a/packages/openapi-to-graphql-cli/src/openapi-to-graphql.ts
+++ b/packages/openapi-to-graphql-cli/src/openapi-to-graphql.ts
@@ -290,7 +290,11 @@ function startGraphQLServer<TSource, TContext, TArgs>(
       }
     })
     .catch((err) => {
-      console.log('OpenAPI-to-GraphQL creation event error:', err.message)
+      if (typeof err === 'string') {
+        console.log('OpenAPI-to-GraphQL creation event error:', err)
+      } else {
+        console.log('OpenAPI-to-GraphQL creation event error:', err.message)
+      }
     })
 }
 


### PR DESCRIPTION
I was losing the error message in the case when what was bubbling up was a string