### PR TITLE
Export translateOpenAPIToGraphQL

### DIFF
--- a/packages/openapi-to-graphql/src/index.ts
+++ b/packages/openapi-to-graphql/src/index.ts
@@ -171,7 +171,7 @@ export async function createGraphQLSchema<TSource, TContext, TArgs>(
 /**
  * Creates a GraphQL interface from the given OpenAPI Specification 3
  */
-function translateOpenAPIToGraphQL<TSource, TContext, TArgs>(
+export function translateOpenAPIToGraphQL<TSource, TContext, TArgs>(
   oass: Oas3[],
   {
     strict,


### PR DESCRIPTION
Export translateOpenAPIToGraphQL to let users bypass OAS validation and swagger openapi translation which will help reduce the bundle size if people want to exclude oas validator and swagger converter libs in the final bundle