### PR TITLE
Add support for query parameters in generated http request to match OAS query parameters serialization expectation

### DIFF
--- a/packages/openapi-to-graphql/src/resolver_builder.ts
+++ b/packages/openapi-to-graphql/src/resolver_builder.ts
@@ -1292,7 +1292,23 @@ export function extractRequestDataFromArgs<TSource, TContext, TArgs>(
 
         // Query parameters
         case 'query':
-          qs[param.name] = args[saneParamName]
+          // setting param style as form assumes explode is true by default
+          if (param.style === 'form' && Object.prototype.toString.call(args[saneParamName]) === '[object Object]') {
+            if (param.explode === false) {
+              qs[param.name] = Object.entries(args[saneParamName]).reduce((acc, val) => {
+                acc += val.join(',')
+                return acc
+              }, '')
+            } else {
+              Object.entries(args[saneParamName]).forEach(([key, value]) => {
+                qs[key] = value
+              })
+            }
+          } else if (Array.isArray(args[saneParamName]) && param.style === 'form' && param.explode !== false) {
+            qs[param.name] = args[saneParamName].join(',')
+          } else {
+            qs[param.name] = args[saneParamName]
+          }
           break
 
         // Header parameters


### PR DESCRIPTION
Hi,
I discovered that the style formatting for query parameters as defined in the [Open API Specification](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#style-values) is not being respected.

Given the partial definition; 

```
"/api/path": {
  get: {
   "parameters" : [ {
          "name" : "parameters",
          "in" : "query",
          "required" : true,
          "style" : "form",
          "explode" : true,
          "schema" : {
            "$ref" : "#/components/schemas/SomeSchemaInput"
          }
    } ],
  }
}
```

where `SomeSchemaInput` has properties of `filter` and `limit` for example, I found that the http request made for the generated GraphQL resolver is of the format; `http://{baseUrl}/api/path?parameters[limit]=10&parameters[offset]=10`.

The http request url should be `http://{baseUrl}/api/path?limit=10&offset=10` considering the provided values for `style` and `explode`, as defined in Open API specification.

I've added a PR to support this behaviour although both for objects and arrays, I have not made `style: form` the default as defined here https://swagger.io/docs/specification/serialization/ for queries.

* EDIT

I've also realized that even with the changes I've made some of the standard behaviour of arrays are ignored because of how the query params get constructed for object like primitives as seen here https://github.com/IBM/openapi-to-graphql/blob/master/packages/openapi-to-graphql/src/resolver_builder.ts#L1332-L1335, this related to https://github.com/IBM/openapi-to-graphql/pull/312 where a solution with used the native query string implementation was introduced. I'd be willing to take on the effort to make parameters behaviour in the package match the standard open api behaviour.