### PR TITLE
Make sure openapi-to-graphql can run as cli script

### DIFF
--- a/packages/openapi-to-graphql-cli/package.json
+++ b/packages/openapi-to-graphql-cli/package.json
@@ -83,5 +83,12 @@
   "scripts": {
     "dev": "tsc -w",
     "build": "tsc --project ../../tsconfig.build.json"
+  },
+  "buildOptions": {
+    "bin": {
+      "openapi-to-graphql": {
+        "input": "src/index.ts"
+      }
+    }
   }
 }


### PR DESCRIPTION
In version 2.5.1 the build options [was removed](https://github.com/IBM/openapi-to-graphql/compare/2.5.0...v2.5.1#diff-5e6764278ef49355318470b7be148c7f6ca6e4bba7826bccdc3e282f5530ae5dL83).

This made it impossible for the cli tool to work properly as described in #418