### PR TITLE
Extend OAS implementations

### DIFF
--- a/packages/openapi-to-graphql/src/resolver_builder.ts
+++ b/packages/openapi-to-graphql/src/resolver_builder.ts
@@ -1360,7 +1360,23 @@ export function extractRequestDataFromArgs<TSource, TContext, TArgs>(
 
         // Query parameters
         case 'query':
-          qs[param.name] = args[saneParamName]
+          // setting param style as form assumes explode is true by default
+          if (param.style === 'form' && Object.prototype.toString.call(args[saneParamName]) === '[object Object]') {
+            if (param.explode === false) {
+              qs[param.name] = Object.entries(args[saneParamName]).reduce((acc, val) => {
+                acc += val.join(',')
+                return acc
+              }, '')
+            } else {
+              Object.entries(args[saneParamName]).forEach(([key, value]) => {
+                qs[key] = value
+              })
+            }
+          } else if (Array.isArray(args[saneParamName]) && param.style === 'form' && param.explode !== false) {
+            qs[param.name] = args[saneParamName].join(',')
+          } else {
+            qs[param.name] = args[saneParamName]
+          }
           break
 
         // Header parameters

--- a/packages/openapi-to-graphql/src/resolver_builder.ts
+++ b/packages/openapi-to-graphql/src/resolver_builder.ts
@@ -349,7 +349,7 @@ function inferLinkArguments<TSource, TContext, TArgs>({
   source,
   args
 }: inferLinkArgumentsParam<TSource, TContext, TArgs>)  {
-  if (Object.prototype.toString.call(value) === '[object Object]') {
+  if (typeof value === 'object') {
     return Object.entries(value).reduce((acc, [key, value]) => {
       acc[key] = inferLinkArguments({paramName, value, resolveData, source, args})
       return acc
@@ -1373,7 +1373,7 @@ export function extractRequestDataFromArgs<TSource, TContext, TArgs>(
         // Query parameters
         case 'query':
           // setting param style as form assumes explode is true by default
-          if (param.style === 'form' && Object.prototype.toString.call(args[saneParamName]) === '[object Object]') {
+          if (param.style === 'form' && typeof args[saneParamName] === 'object') {
             if (param.explode === false) {
               qs[param.name] = Object.entries(args[saneParamName]).reduce((acc, val) => {
                 acc += val.join(',')

--- a/packages/openapi-to-graphql/test/example_api.test.ts
+++ b/packages/openapi-to-graphql/test/example_api.test.ts
@@ -2412,7 +2412,7 @@ test('Non-nullable properties from nested allOf', () => {
   })
 })
 
-test('it formats the request url appropriate when style and explode is set to true', async () => {
+test('Format the query params appropriately when style and explode are set to true', async () => {
   const LIMIT = 10
   const OFFSET = 0
 

--- a/packages/openapi-to-graphql/test/example_api.test.ts
+++ b/packages/openapi-to-graphql/test/example_api.test.ts
@@ -2411,3 +2411,32 @@ test('Non-nullable properties from nested allOf', () => {
     })
   })
 })
+
+test('it formats the request url appropriate when style and explode is set to true', async () => {
+  const LIMIT = 10
+  const OFFSET = 0
+
+  const query = `
+    query {
+      fetchAllOfficesWithFormStyleAndExplodeTrue(parameters: { limit: ${LIMIT}, offset: ${OFFSET} }) {
+        roomNumber
+        company {
+          id
+        }
+      }
+    }
+  `
+
+  await graphql(createdSchema, query).then((result) => {
+    // target error field because the corresponding server url is not implemented,
+    // also we get the full request url as in failed request errors
+    result.errors.forEach((error) => {
+      const url = new URL(error.extensions.url)
+
+      expect(url.searchParams.has('limit')).toBe(true)
+      expect(url.searchParams.get('limit')).toBe(String(LIMIT))
+      expect(url.searchParams.has('offset')).toBe(true)
+      expect(url.searchParams.get('offset')).toBe(String(OFFSET))
+    })
+  })
+})

--- a/packages/openapi-to-graphql/test/fixtures/example_oas.json
+++ b/packages/openapi-to-graphql/test/fixtures/example_oas.json
@@ -471,6 +471,46 @@
         }
       }
     },
+    "/offices": {
+      "get": {
+        "x-graphql-field-name": "fetchAllOfficesWithFormStyleAndExplodeTrue",
+        "operationId": "returnAllOffices",
+        "description": "returns all offices",
+        "parameters": [{
+          "name": "parameters",
+          "in": "query",
+          "required": true,
+          "style": "form",
+          "explode": true,
+          "schema": {
+            "type": "object",
+            "properties": {
+              "limit": {
+                "type": "integer"
+              },
+              "offset": {
+                "type": "integer"
+              }
+            }
+          }
+        }],
+        "responses": {
+          "200": {
+            "description": "A list of users.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/office"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/offices/{id}": {
       "get": {
         "operationId": "getOffice",


### PR DESCRIPTION
Hi, following our discussion in https://github.com/IBM/openapi-to-graphql/pull/426 , I decided to open a different PR to tackle couple of issues I found pertaining to how the definitions from an OAS might be processed.

Here's a couple of issues the PR addresses; 

- Fixes implementation where the `style` and `explode` properties for endpoint parameters didn't adhere to the Open API Spec. Given the partial definition;
    ```
    "/api/path": {
      get: {
       "parameters" : [ {
              "name" : "parameters",
              "in" : "query",
              "required" : true,
              "style" : "form",
              "explode" : true,
              "schema" : {
                "$ref" : "#/components/schemas/SomeSchemaInput"
              }
        } ],
      }
    }
    ```
    where `SomeSchemaInput` has properties of `filter` and `limit` for example, I found that the http request made for the generated GraphQL resolver is of the format; `http://{baseUrl}/api/path?parameters[limit]=10&parameters[offset]=10` when the http request url should rather be `http://{baseUrl}/api/path?limit=10&offset=10` considering the provided values for style and explode, as defined in Open API specification. Relates to https://github.com/IBM/openapi-to-graphql/pull/312 but also includes support for Arrays and Objects
- Also fix issue where an error is thrown when link is created with parameter that's a nested object; for instance given the link definition;
    
    ```
    ...
            responses: {
              200: {
                links: {
                  invitations: {
                    operationId: 'someOperationId',
                    parameters: {
                      filter: {
                        entityId: '$response.body#/id',
                      },
                    },
                  },
                },
              },
    
    ```
    previously filter would be attempted to be processed as a string, which resulted in errors.