### PR TITLE
check operation responseContentType before checking if it includes a content type

### DIFF
--- a/packages/openapi-to-graphql/src/resolver_builder.ts
+++ b/packages/openapi-to-graphql/src/resolver_builder.ts
@@ -772,7 +772,7 @@ export function getResolver<TSource, TContext, TArgs>({
     } else {
       httpLog(`${response.status} - ${Oas3Tools.trim(body, 100)}`)
 
-      if (response.headers.get('content-type')) {
+      if (response.headers.get('content-type') && operation.responseContentType) {
         /**
          * Throw warning if the non-application/json content does not
          * match the OAS.


### PR DESCRIPTION
Some API implementations will respond with a content type header for a `204 NO_CONTENT` response. The existence of that header allows for the code to call includes on a variable that is possibly undefined.

* check operation responseContentType before trying to check if it includes a content type

Fixes #448 