### PR TITLE
Handle recursive union types

### DIFF
--- a/packages/openapi-to-graphql/src/schema_builder.ts
+++ b/packages/openapi-to-graphql/src/schema_builder.ts
@@ -396,13 +396,6 @@ function createOrReuseUnion<TSource, TContext, TArgs>({
       }
     )
 
-    /**
-     * Check for ambiguous member types
-     *
-     * i.e. member types that can be confused with each other.
-     */
-    checkAmbiguousMemberTypes(def, types, data)
-
     def.graphQLType = new GraphQLUnionType({
       name: def.graphQLTypeName,
       description,
@@ -435,6 +428,13 @@ function createOrReuseUnion<TSource, TContext, TArgs>({
         })
       }
     })
+
+    /**
+     * Check for ambiguous member types
+     *
+     * i.e. member types that can be confused with each other.
+     */
+    checkAmbiguousMemberTypes(def, types, data)
 
     return def.graphQLType
   }


### PR DESCRIPTION
checkAmbiguousMemberTypes might trigger calls to createOrReuseUnion when
fetching the fields of a given type. However, if graphQLType is not
defined yet, it will try to create it instead of returning the
previously created one. In order to reuse graphQLType without creating a
new one, we need to call checkAmbiguousMemberTypes **after** assigning
the graphQLType to the current definition.

Motivation: https://github.com/IBM/openapi-to-graphql/issues/451

Signed-off-by: Simon Meyffret <smeyffret@gmail.com>